### PR TITLE
refactor(comment): Use string values for VoteType enum

### DIFF
--- a/frontend/src/app/models/comment.model.ts
+++ b/frontend/src/app/models/comment.model.ts
@@ -1,6 +1,6 @@
 export enum VoteType {
-    UpVote = 1,
-    DownVote = -1
+    UpVote = 'UpVote',
+    DownVote = 'DownVote'
 }
 
 export interface ChargePointComment {


### PR DESCRIPTION
Corrected to use same enum values as backend