### PR TITLE
Fix memory leaks from unmanaged RxJS subscriptions

### DIFF
--- a/frontend/src/app/admin-feedback/admin-feedback.component.ts
+++ b/frontend/src/app/admin-feedback/admin-feedback.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -39,6 +40,7 @@ export class AdminFeedbackComponent implements OnInit {
     private feedbackService = inject(FeedbackService);
     private snackBar = inject(MatSnackBar);
     private router = inject(Router);
+    private destroyRef = inject(DestroyRef);
     authService = inject(AuthService);
 
     feedbacks: Feedback[] = [];
@@ -57,19 +59,22 @@ export class AdminFeedbackComponent implements OnInit {
 
     loadFeedback() {
         this.isLoading = true;
-        this.feedbackService.getAllFeedback().subscribe({
-            next: (feedbacks) => {
-                this.feedbacks = feedbacks;
-                this.isLoading = false;
-            },
-            error: (error) => {
-                console.error('Error loading feedback:', error);
-                this.snackBar.open('Kunde inte ladda feedback', 'Stäng', {
-                    duration: 3000
-                });
-                this.isLoading = false;
-            }
-        });
+        this.feedbackService
+            .getAllFeedback()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: (feedbacks) => {
+                    this.feedbacks = feedbacks;
+                    this.isLoading = false;
+                },
+                error: (error) => {
+                    console.error('Error loading feedback:', error);
+                    this.snackBar.open('Kunde inte ladda feedback', 'Stäng', {
+                        duration: 3000
+                    });
+                    this.isLoading = false;
+                }
+            });
     }
 
     deleteFeedback(feedback: Feedback) {
@@ -79,42 +84,48 @@ export class AdminFeedbackComponent implements OnInit {
             return;
         }
 
-        this.feedbackService.deleteFeedback(feedback.id).subscribe({
-            next: () => {
-                this.feedbacks = this.feedbacks.filter(f => f.id !== feedback.id);
-                this.snackBar.open('Feedback borttagen', 'Stäng', {
-                    duration: 3000
-                });
-            },
-            error: (error) => {
-                console.error('Error deleting feedback:', error);
-                this.snackBar.open('Kunde inte ta bort feedback', 'Stäng', {
-                    duration: 3000
-                });
-            }
-        });
+        this.feedbackService
+            .deleteFeedback(feedback.id)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: () => {
+                    this.feedbacks = this.feedbacks.filter(f => f.id !== feedback.id);
+                    this.snackBar.open('Feedback borttagen', 'Stäng', {
+                        duration: 3000
+                    });
+                },
+                error: (error) => {
+                    console.error('Error deleting feedback:', error);
+                    this.snackBar.open('Kunde inte ta bort feedback', 'Stäng', {
+                        duration: 3000
+                    });
+                }
+            });
     }
 
     toggleHandled(feedback: Feedback) {
         if (!feedback.id) return;
 
         const newStatus = !feedback.isHandled;
-        this.feedbackService.markAsHandled(feedback.id, newStatus).subscribe({
-            next: () => {
-                feedback.isHandled = newStatus;
-                this.snackBar.open(
-                    newStatus ? 'Markerad som hanterad' : 'Markerad som ohanterad',
-                    'Stäng',
-                    { duration: 2000 }
-                );
-            },
-            error: (error) => {
-                console.error('Error updating feedback status:', error);
-                this.snackBar.open('Kunde inte uppdatera status', 'Stäng', {
-                    duration: 3000
-                });
-            }
-        });
+        this.feedbackService
+            .markAsHandled(feedback.id, newStatus)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: () => {
+                    feedback.isHandled = newStatus;
+                    this.snackBar.open(
+                        newStatus ? 'Markerad som hanterad' : 'Markerad som ohanterad',
+                        'Stäng',
+                        { duration: 2000 }
+                    );
+                },
+                error: (error) => {
+                    console.error('Error updating feedback status:', error);
+                    this.snackBar.open('Kunde inte uppdatera status', 'Stäng', {
+                        duration: 3000
+                    });
+                }
+            });
     }
 
     startEditingResponse(feedback: Feedback) {
@@ -130,22 +141,25 @@ export class AdminFeedbackComponent implements OnInit {
     saveResponse(feedback: Feedback) {
         if (!feedback.id) return;
 
-        this.feedbackService.updateAdminResponse(feedback.id, this.tempResponse).subscribe({
-            next: () => {
-                feedback.adminResponse = this.tempResponse;
-                this.editingResponseId = null;
-                this.tempResponse = '';
-                this.snackBar.open('Svar sparat', 'Stäng', {
-                    duration: 2000
-                });
-            },
-            error: (error) => {
-                console.error('Error saving response:', error);
-                this.snackBar.open('Kunde inte spara svar', 'Stäng', {
-                    duration: 3000
-                });
-            }
-        });
+        this.feedbackService
+            .updateAdminResponse(feedback.id, this.tempResponse)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: () => {
+                    feedback.adminResponse = this.tempResponse;
+                    this.editingResponseId = null;
+                    this.tempResponse = '';
+                    this.snackBar.open('Svar sparat', 'Stäng', {
+                        duration: 2000
+                    });
+                },
+                error: (error) => {
+                    console.error('Error saving response:', error);
+                    this.snackBar.open('Kunde inte spara svar', 'Stäng', {
+                        duration: 3000
+                    });
+                }
+            });
     }
 
     getFeedbackTypeLabel(type: FeedbackType): string {

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
@@ -74,6 +75,7 @@ export class HomeComponent implements OnInit {
     private backupService = inject(BackupService);
     protected shareService = inject(ShareService);
     private snackBar = inject(MatSnackBar);
+    private destroyRef = inject(DestroyRef);
 
     protected unhandledFeedbackCount = 0;
 
@@ -157,12 +159,14 @@ export class HomeComponent implements OnInit {
             this.loadUnhandledSuggestionsCount();
         }
 
-        this.connectionService.online$.subscribe((isOnline) => {
-            this.isOnline = isOnline;
-            if (isOnline && this.identifiedChargePoints.length === 0) {
-                this.loadChargingPoints();
-            }
-        });
+        this.connectionService.online$
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((isOnline) => {
+                this.isOnline = isOnline;
+                if (isOnline && this.identifiedChargePoints.length === 0) {
+                    this.loadChargingPoints();
+                }
+            });
     }
 
     navigateToEdit(point: IdentifiedCaravanChargePoint): void {
@@ -239,31 +243,37 @@ export class HomeComponent implements OnInit {
     }
 
     private loadUnhandledFeedbackCount(): void {
-        this.feedbackService.getUnhandledCount().subscribe({
-            next: (count) => {
-                this.unhandledFeedbackCount = count;
-            },
-            error: (error) => {
-                console.error('Error loading unhandled feedback count:', error);
-                // Silently fail - not critical
-            },
-        });
+        this.feedbackService
+            .getUnhandledCount()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: (count) => {
+                    this.unhandledFeedbackCount = count;
+                },
+                error: (error) => {
+                    console.error('Error loading unhandled feedback count:', error);
+                    // Silently fail - not critical
+                },
+            });
     }
 
     protected unhandledSuggestionsCount = 0;
 
     private loadUnhandledSuggestionsCount(): void {
-        this.chargingStationService.getSuggestedCount().subscribe({
-            next: (count) => {
-                this.unhandledSuggestionsCount = count;
-            },
-            error: (error) => {
-                console.error(
-                    'Error loading unhandled suggestions count:',
-                    error
-                );
-            },
-        });
+        this.chargingStationService
+            .getSuggestedCount()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: (count) => {
+                    this.unhandledSuggestionsCount = count;
+                },
+                error: (error) => {
+                    console.error(
+                        'Error loading unhandled suggestions count:',
+                        error
+                    );
+                },
+            });
     }
 
     protected getImageUrl(id: number): string {

--- a/frontend/src/app/map/map.component.ts
+++ b/frontend/src/app/map/map.component.ts
@@ -4,7 +4,9 @@ import {
     AfterViewInit,
     ApplicationRef,
     Component,
+    ComponentRef,
     createComponent,
+    DestroyRef,
     EnvironmentInjector,
     EventEmitter,
     inject,
@@ -15,6 +17,7 @@ import {
     Output,
     SimpleChanges,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -54,6 +57,8 @@ export class MapComponent
     public shareService = inject(ShareService);
     private appRef = inject(ApplicationRef);
     private injector = inject(EnvironmentInjector);
+    private destroyRef = inject(DestroyRef);
+    private popupComponentRefs: ComponentRef<ChargePointPopupComponent>[] = [];
 
     public searchQuery: string = '';
     public searchResults: any[] = [];
@@ -96,9 +101,17 @@ export class MapComponent
     }
 
     ngOnDestroy(): void {
+        this.destroyPopupComponents();
         if (this.map) {
             this.map.remove();
         }
+    }
+
+    private destroyPopupComponents(): void {
+        for (const ref of this.popupComponentRefs) {
+            ref.destroy();
+        }
+        this.popupComponentRefs = [];
     }
 
     private initMap(): void {
@@ -166,8 +179,9 @@ export class MapComponent
             return;
         }
 
-        // Clear existing markers
+        // Clear existing markers and destroy any popup components attached to them
         this.markerClusterGroup.clearLayers();
+        this.destroyPopupComponents();
 
         let markersCount = 0;
 
@@ -265,22 +279,28 @@ export class MapComponent
         componentRef.instance.isAuthenticated =
             this.authService.isAuthenticated();
 
-        // Subscribe to outputs
-        componentRef.instance.edit.subscribe(() => {
+        // Subscribe to outputs. Subscriptions are released when the
+        // componentRef is destroyed (in destroyPopupComponents / ngOnDestroy),
+        // or if the MapComponent itself is destroyed first via takeUntilDestroyed.
+        const untilDestroyed = takeUntilDestroyed(this.destroyRef);
+        componentRef.instance.edit.pipe(untilDestroyed).subscribe(() => {
             this.editChargePoint.emit(point);
         });
 
-        componentRef.instance.delete.subscribe(() => {
+        componentRef.instance.delete.pipe(untilDestroyed).subscribe(() => {
             this.deleteChargePoint.emit(point);
             this.map?.closePopup();
         });
 
-        componentRef.instance.viewComments.subscribe(() => {
+        componentRef.instance.viewComments.pipe(untilDestroyed).subscribe(() => {
             this.viewComments.emit(point);
         });
 
         // Attach to the application
         this.appRef.attachView(componentRef.hostView);
+
+        // Track for later destruction
+        this.popupComponentRefs.push(componentRef);
 
         // Get the DOM element
         const domElem = (componentRef.hostView as any)


### PR DESCRIPTION
Long-lived subscriptions in HomeComponent, AdminFeedbackComponent and MapComponent were never torn down when the component was destroyed, keeping the component instance alive each time the user navigated away and returned. MapComponent additionally created ChargePointPopupComponent instances via createComponent() for every Leaflet marker popup and never destroyed them, so each refresh of the charge-point list leaked one Angular component per marker.

Subscriptions are now tied to the component lifecycle with takeUntilDestroyed(DestroyRef), and the map tracks every popup component reference and destroys them both when markers are re-rendered and when the map itself is torn down. Users should see reduced memory growth when switching views or reloading data repeatedly.