### PR TITLE
Patch fast-uri to fix high-severity vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5379,9 +5379,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "@modelcontextprotocol/sdk": "1.26.0",
     "hono": "4.12.5",
     "@hono/node-server": "1.19.11",
+    "fast-uri": "3.1.2",
     "immutable": "5.1.5",
     "rollup": ">=4.59.0",
     "minimatch@>=10": {


### PR DESCRIPTION
Override transitive fast-uri dependency (pulled in via @angular/cli → ajv) to version 3.1.2, which fixes CVE-2026-6321 (path traversal via percent-encoded dot segments) and CVE-2026-6322 (host confusion via percent-encoded authority delimiters).