### PR TITLE
Add frontend unit and integration tests

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -92,33 +92,11 @@
                     "builder": "@angular/build:extract-i18n"
                 },
                 "test": {
-                    "builder": "@angular/build:karma",
+                    "builder": "@angular/build:unit-test",
                     "options": {
-                        "polyfills": ["zone.js", "zone.js/testing"],
                         "tsConfig": "tsconfig.spec.json",
-                        "inlineStyleLanguage": "scss",
-                        "assets": [
-                            {
-                                "glob": "**/*",
-                                "input": "public"
-                            },
-                            {
-                                "glob": "**/*",
-                                "input": "src/assets",
-                                "output": "/assets/"
-                            }
-                        ],
-                        "styles": [
-                          "@angular/material/prebuilt-themes/azure-blue.css",
-                          "node_modules/leaflet/dist/leaflet.css",
-                          "node_modules/leaflet.markercluster/dist/MarkerCluster.css",
-                          "node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css",
-                          "src/styles.scss"
-                        ],
-                        "scripts": [
-                          "node_modules/leaflet/dist/leaflet.js",
-                          "node_modules/leaflet.markercluster/dist/leaflet.markercluster.js"
-                        ]
+                        "runner": "vitest",
+                        "buildTarget": "elbil-husvagn-ladda:build:development"
                     }
                 }
             }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,14 +33,9 @@
         "@angular/build": "^21.2.1",
         "@angular/cli": "^21.2.1",
         "@angular/compiler-cli": "^21.2.4",
-        "@types/jasmine": "~5.1.0",
-        "jasmine-core": "~5.1.0",
-        "karma": "~6.4.0",
-        "karma-chrome-launcher": "~3.2.0",
-        "karma-coverage": "~2.2.0",
-        "karma-jasmine": "~5.1.0",
-        "karma-jasmine-html-reporter": "~2.1.0",
-        "typescript": "~5.9.3"
+        "jsdom": "^25.0.0",
+        "typescript": "~5.9.3",
+        "vitest": "^4.0.8"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -753,6 +748,27 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -1046,14 +1062,119 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3842,17 +3963,10 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@tufjs/canonical-json": {
@@ -3906,15 +4020,23 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3935,13 +4057,6 @@
       "integrity": "sha512-fFxMtjAvXXMYTzDFK5NpcVB7WHnrHVLl00QzEGpuFxSAC789io6M+vjcn+g5FTEamIJtJr/IHkCDsqvJxeWDyw==",
       "license": "MIT"
     },
-    "node_modules/@types/jasmine": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.13.tgz",
-      "integrity": "sha512-MYCcDkruFc92LeYZux5BC0dmqo2jk+M5UIZ4/oFnAPCXN9mCcQhLyj7F3/Za7rocVyt5YRr1MmqJqFlvQ9LVcg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/leaflet": {
       "version": "1.9.21",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
@@ -3960,16 +4075,6 @@
         "@types/leaflet": "^1.9"
       }
     },
-    "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.4.tgz",
@@ -3982,6 +4087,126 @@
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -4127,19 +4352,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 8"
+        "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -4149,16 +4377,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/base64id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^4.5.0 || >= 5.9"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -4190,19 +4408,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -4248,19 +4453,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -4432,6 +4624,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -4613,96 +4815,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
-      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.2",
-        "parseurl": "~1.3.3",
-        "utils-merge": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/connect/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/connect/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
+        "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -4815,21 +4938,39 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/custom-event": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -4850,6 +4991,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4858,17 +5016,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -4880,26 +5027,6 @@
       "optional": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/di": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dom-serialize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -5007,118 +5134,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/engine.io": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
-      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.7.2",
-        "cors": "~2.8.5",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "punycode": "^1.4.1",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -5182,6 +5197,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5190,6 +5212,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5254,6 +5292,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5263,13 +5311,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -5292,6 +5333,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -5364,13 +5415,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5413,19 +5457,6 @@
         }
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -5448,32 +5479,44 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
       "license": "MIT",
       "engines": {
-        "node": ">=4.0"
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
       },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -5496,21 +5539,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
@@ -5523,13 +5551,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5628,41 +5649,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -5689,16 +5675,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -5775,12 +5751,18 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -5841,21 +5823,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5949,18 +5916,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5998,25 +5953,13 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6043,6 +5986,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6063,15 +6007,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -6079,25 +6020,6 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
@@ -6110,19 +6032,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
     "node_modules/isexe": {
@@ -6159,67 +6068,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jasmine-core": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.1.2.tgz",
-      "integrity": "sha512-2oIUMGn00FdUiqz6epiiJr7xcFyNYj3rDcfmnzfkBnHyBQ3cBQUs4mmyGsOb7TTLb9kxk7dBcmEmqhDKkBoDyA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -6236,6 +6084,95 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6294,16 +6231,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -6321,444 +6248,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/karma": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
-      "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "body-parser": "^1.19.0",
-        "braces": "^3.0.2",
-        "chokidar": "^3.5.1",
-        "connect": "^3.7.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.1",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "http-proxy": "^1.18.1",
-        "isbinaryfile": "^4.0.8",
-        "lodash": "^4.17.21",
-        "log4js": "^6.4.1",
-        "mime": "^2.5.2",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.5",
-        "qjobs": "^1.2.0",
-        "range-parser": "^1.2.1",
-        "rimraf": "^3.0.2",
-        "socket.io": "^4.7.2",
-        "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
-        "ua-parser-js": "^0.7.30",
-        "yargs": "^16.1.1"
-      },
-      "bin": {
-        "karma": "bin/karma"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/karma-chrome-launcher": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz",
-      "integrity": "sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which": "^1.2.1"
-      }
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/karma-coverage": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
-      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.1",
-        "istanbul-reports": "^3.0.5",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/karma-jasmine": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
-      "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jasmine-core": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "karma": "^6.0.0"
-      }
-    },
-    "node_modules/karma-jasmine-html-reporter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.1.0.tgz",
-      "integrity": "sha512-sPQE1+nlsn6Hwb5t+HHwyy0A1FNCVKuL1192b+XNauMYWThz2kweiBVW1DqloRpVvZIJkIoHVB7XRpK78n1xbQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "jasmine-core": "^4.0.0 || ^5.0.0",
-        "karma": "^6.0.0",
-        "karma-jasmine": "^5.0.0"
-      }
-    },
-    "node_modules/karma-jasmine/node_modules/jasmine-core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
-      "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/karma/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/karma/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/karma/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/karma/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/karma/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/karma/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/leaflet": {
@@ -6866,13 +6355,6 @@
         "@lmdb/lmdb-win32-x64": "3.5.1"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-symbols": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
@@ -6946,23 +6428,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6981,22 +6446,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -7055,19 +6504,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -7106,47 +6542,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -7280,19 +6675,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mrmime": {
@@ -7496,16 +6878,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/npm-bundled": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
@@ -7621,6 +6993,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7643,6 +7022,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -7834,16 +7224,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7891,6 +7271,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8046,23 +7433,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/qjobs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
-      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.9"
-      }
-    },
     "node_modules/qs": {
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
@@ -8126,16 +7496,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8145,13 +7505,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
@@ -8186,23 +7539,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.4",
@@ -8298,6 +7634,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -8305,24 +7648,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safer-buffer": {
@@ -8381,6 +7706,19 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -8549,6 +7887,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8606,133 +7951,6 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socket.io": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
-      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "base64id": "~2.0.0",
-        "cors": "~2.8.5",
-        "debug": "~4.3.2",
-        "engine.io": "~6.6.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/socks": {
@@ -8844,6 +8062,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8853,6 +8078,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.1",
@@ -8865,21 +8097,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/string-width": {
@@ -8915,18 +8132,12 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "7.5.11",
@@ -8955,6 +8166,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8972,28 +8200,35 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.14"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-number": "^7.0.0"
+        "tldts-core": "^6.1.86"
       },
-      "engines": {
-        "node": ">=8.0"
+      "bin": {
+        "tldts": "bin/cli.js"
       }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -9003,6 +8238,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tr46/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -9055,33 +8326,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
-      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/undici": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -9091,13 +8335,6 @@
       "engines": {
         "node": ">=20.18.1"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "5.0.0",
@@ -9123,16 +8360,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -9174,16 +8401,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/validate-npm-package-name": {
@@ -9281,14 +8498,107 @@
         }
       }
     },
-    "node_modules/void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/watchpack": {
@@ -9313,6 +8623,67 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9327,6 +8698,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -9422,27 +8810,22 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=18"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,14 +41,9 @@
     "@angular/build": "^21.2.1",
     "@angular/cli": "^21.2.1",
     "@angular/compiler-cli": "^21.2.4",
-    "@types/jasmine": "~5.1.0",
-    "jasmine-core": "~5.1.0",
-    "karma": "~6.4.0",
-    "karma-chrome-launcher": "~3.2.0",
-    "karma-coverage": "~2.2.0",
-    "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.9.3"
+    "jsdom": "^25.0.0",
+    "typescript": "~5.9.3",
+    "vitest": "^4.0.8"
   },
   "overrides": {
     "vite": "7.3.2",

--- a/frontend/src/app/admin-feedback/admin-feedback.component.spec.ts
+++ b/frontend/src/app/admin-feedback/admin-feedback.component.spec.ts
@@ -1,0 +1,180 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../auth/auth.service';
+import { Feedback, FeedbackType } from '../models/feedback.model';
+import { FeedbackService } from '../services/feedback.service';
+import { AdminFeedbackComponent } from './admin-feedback.component';
+
+describe('AdminFeedbackComponent', () => {
+    let feedbackService: {
+        getAllFeedbackPaged: ReturnType<typeof vi.fn>;
+        getUnhandledCount: ReturnType<typeof vi.fn>;
+        deleteFeedback: ReturnType<typeof vi.fn>;
+        markAsHandled: ReturnType<typeof vi.fn>;
+        updateAdminResponse: ReturnType<typeof vi.fn>;
+    };
+    let auth: { isAuthenticated: ReturnType<typeof vi.fn> };
+    let router: { navigate: ReturnType<typeof vi.fn> };
+    let snackBar: { open: ReturnType<typeof vi.fn> };
+
+    function makeFeedback(overrides: Partial<Feedback> = {}): Feedback {
+        return {
+            id: 1,
+            type: FeedbackType.Improvement,
+            title: 'Test',
+            description: 'desc',
+            isHandled: false,
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        feedbackService = {
+            getAllFeedbackPaged: vi.fn().mockReturnValue(of({ items: [], total: 0, page: 1, pageSize: 20 })),
+            getUnhandledCount: vi.fn().mockReturnValue(of(0)),
+            deleteFeedback: vi.fn().mockReturnValue(of(void 0)),
+            markAsHandled: vi.fn().mockReturnValue(of(void 0)),
+            updateAdminResponse: vi.fn().mockReturnValue(of(void 0)),
+        };
+        auth = { isAuthenticated: vi.fn().mockReturnValue(true) };
+        router = { navigate: vi.fn() };
+        snackBar = { open: vi.fn() };
+
+        TestBed.configureTestingModule({
+            imports: [AdminFeedbackComponent],
+            providers: [
+                { provide: FeedbackService, useValue: feedbackService },
+                { provide: AuthService, useValue: auth },
+                { provide: Router, useValue: router },
+                { provide: MatSnackBar, useValue: snackBar },
+            ],
+        });
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    function create(): AdminFeedbackComponent {
+        const fixture = TestBed.createComponent(AdminFeedbackComponent);
+        const c = fixture.componentInstance;
+        c.ngOnInit();
+        return c;
+    }
+
+    it('redirects to /login when not authenticated', () => {
+        auth.isAuthenticated.mockReturnValue(false);
+        const fixture = TestBed.createComponent(AdminFeedbackComponent);
+        fixture.componentInstance.ngOnInit();
+
+        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+        expect(feedbackService.getAllFeedbackPaged).not.toHaveBeenCalled();
+    });
+
+    it('clamps pageIndex back when current page exceeds last after a load', () => {
+        feedbackService.getAllFeedbackPaged.mockReturnValueOnce(
+            of({ items: [], total: 10, page: 5, pageSize: 20 }),
+        ).mockReturnValueOnce(
+            of({ items: [makeFeedback()], total: 10, page: 1, pageSize: 20 }),
+        );
+
+        const c = create();
+        c.pageIndex = 4;
+        c.loadFeedback();
+
+        expect(c.pageIndex).toBe(0);
+        // 1 from ngOnInit, 1 from manual loadFeedback, 1 from the clamp-recall
+        expect(feedbackService.getAllFeedbackPaged).toHaveBeenCalledTimes(3);
+    });
+
+    it('toggleHandled flips local state and refreshes unhandled count on success', () => {
+        const c = create();
+        const fb = makeFeedback({ isHandled: false });
+
+        c.toggleHandled(fb);
+
+        expect(feedbackService.markAsHandled).toHaveBeenCalledWith(1, true);
+        expect(fb.isHandled).toBe(true);
+        // once from ngOnInit, once after toggle
+        expect(feedbackService.getUnhandledCount).toHaveBeenCalledTimes(2);
+    });
+
+    it('toggleHandled does nothing without an id', () => {
+        const c = create();
+        c.toggleHandled(makeFeedback({ id: undefined }));
+        expect(feedbackService.markAsHandled).not.toHaveBeenCalled();
+    });
+
+    it('deleteFeedback aborts when confirm returns false', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+        const c = create();
+
+        c.deleteFeedback(makeFeedback());
+
+        expect(feedbackService.deleteFeedback).not.toHaveBeenCalled();
+    });
+
+    it('deleteFeedback calls service and reloads when confirmed', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const c = create();
+        const callsBefore = feedbackService.getAllFeedbackPaged.mock.calls.length;
+
+        c.deleteFeedback(makeFeedback());
+
+        expect(feedbackService.deleteFeedback).toHaveBeenCalledWith(1);
+        expect(feedbackService.getAllFeedbackPaged).toHaveBeenCalledTimes(callsBefore + 1);
+    });
+
+    it('saveResponse persists value to the feedback object on success', () => {
+        const c = create();
+        const fb = makeFeedback({ adminResponse: 'old' });
+        c.tempResponse = 'new reply';
+        c.editingResponseId = 1;
+
+        c.saveResponse(fb);
+
+        expect(feedbackService.updateAdminResponse).toHaveBeenCalledWith(1, 'new reply');
+        expect(fb.adminResponse).toBe('new reply');
+        expect(c.editingResponseId).toBeNull();
+        expect(c.tempResponse).toBe('');
+    });
+
+    it('saveResponse shows error snackbar on failure', () => {
+        feedbackService.updateAdminResponse.mockReturnValue(throwError(() => new Error('x')));
+        const c = create();
+        c.tempResponse = 'reply';
+
+        c.saveResponse(makeFeedback());
+
+        expect(snackBar.open).toHaveBeenCalledWith('Kunde inte spara svar', 'Stäng', expect.any(Object));
+    });
+
+    it('startEditingResponse and cancelEditingResponse manage temp state', () => {
+        const c = create();
+        c.startEditingResponse(makeFeedback({ id: 7, adminResponse: 'hej' }));
+        expect(c.editingResponseId).toBe(7);
+        expect(c.tempResponse).toBe('hej');
+
+        c.cancelEditingResponse();
+        expect(c.editingResponseId).toBeNull();
+        expect(c.tempResponse).toBe('');
+    });
+
+    it('formatDate returns empty string for undefined', () => {
+        const c = create();
+        expect(c.formatDate(undefined)).toBe('');
+        expect(c.formatDate(new Date('2026-01-15T10:00:00Z'))).not.toBe('');
+    });
+
+    it('type label and color helpers map correctly', () => {
+        const c = create();
+        expect(c.getFeedbackTypeLabel(FeedbackType.Improvement)).toBe('Förbättring');
+        expect(c.getFeedbackTypeLabel(FeedbackType.Bug)).toBe('Bugg');
+        expect(c.getFeedbackTypeColor(FeedbackType.Improvement)).toBe('primary');
+        expect(c.getFeedbackTypeColor(FeedbackType.Bug)).toBe('warn');
+    });
+});

--- a/frontend/src/app/admin-suggestions/admin-suggestions.component.spec.ts
+++ b/frontend/src/app/admin-suggestions/admin-suggestions.component.spec.ts
@@ -1,0 +1,147 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../auth/auth.service';
+import { ChargingPoint, ChargingStationService } from '../services/charging-station.service';
+import { AdminSuggestionsComponent } from './admin-suggestions.component';
+
+describe('AdminSuggestionsComponent', () => {
+    let service: {
+        getSuggestedChargingPointsPaged: ReturnType<typeof vi.fn>;
+        approveSuggestedChargingPoint: ReturnType<typeof vi.fn>;
+        deleteSuggestedChargingPoint: ReturnType<typeof vi.fn>;
+    };
+    let auth: { isAuthenticated: ReturnType<typeof vi.fn> };
+    let router: { navigate: ReturnType<typeof vi.fn> };
+    let snackBar: { open: ReturnType<typeof vi.fn> };
+    let dialog: { open: ReturnType<typeof vi.fn> };
+
+    function makePoint(overrides: Partial<ChargingPoint> = {}): ChargingPoint {
+        return {
+            id: 1,
+            title: 'Stop',
+            address1: 'Main 1',
+            postalCode: '12345',
+            city: 'Town',
+            country: 'SE',
+            mapCoordinates: '59.3,18.0',
+            capacity: 22,
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        service = {
+            getSuggestedChargingPointsPaged: vi.fn().mockReturnValue(of({ items: [], total: 0, page: 1, pageSize: 20 })),
+            approveSuggestedChargingPoint: vi.fn().mockReturnValue(of(makePoint())),
+            deleteSuggestedChargingPoint: vi.fn().mockReturnValue(of(void 0)),
+        };
+        auth = { isAuthenticated: vi.fn().mockReturnValue(true) };
+        router = { navigate: vi.fn() };
+        snackBar = { open: vi.fn() };
+        dialog = { open: vi.fn() };
+
+        TestBed.configureTestingModule({
+            imports: [AdminSuggestionsComponent],
+            providers: [
+                { provide: ChargingStationService, useValue: service },
+                { provide: AuthService, useValue: auth },
+                { provide: Router, useValue: router },
+                { provide: MatSnackBar, useValue: snackBar },
+                { provide: MatDialog, useValue: dialog },
+            ],
+        });
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    function create(): AdminSuggestionsComponent {
+        const fixture = TestBed.createComponent(AdminSuggestionsComponent);
+        const c = fixture.componentInstance;
+        c.ngOnInit();
+        return c;
+    }
+
+    it('redirects to /login when not authenticated', () => {
+        auth.isAuthenticated.mockReturnValue(false);
+        const fixture = TestBed.createComponent(AdminSuggestionsComponent);
+        fixture.componentInstance.ngOnInit();
+
+        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+        expect(service.getSuggestedChargingPointsPaged).not.toHaveBeenCalled();
+    });
+
+    it('clamps pageIndex when current page exceeds last', () => {
+        service.getSuggestedChargingPointsPaged
+            .mockReturnValueOnce(of({ items: [], total: 10, page: 5, pageSize: 20 }))
+            .mockReturnValueOnce(of({ items: [makePoint()], total: 10, page: 1, pageSize: 20 }));
+
+        const c = create();
+        c.pageIndex = 4;
+        c.loadSuggestions();
+
+        expect(c.pageIndex).toBe(0);
+    });
+
+    it('approveSuggestion aborts when confirm is rejected', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+        const c = create();
+
+        c.approveSuggestion(makePoint());
+
+        expect(service.approveSuggestedChargingPoint).not.toHaveBeenCalled();
+    });
+
+    it('approveSuggestion calls service and reloads on success', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const c = create();
+        const before = service.getSuggestedChargingPointsPaged.mock.calls.length;
+
+        c.approveSuggestion(makePoint());
+
+        expect(service.approveSuggestedChargingPoint).toHaveBeenCalledWith(1);
+        expect(service.getSuggestedChargingPointsPaged).toHaveBeenCalledTimes(before + 1);
+    });
+
+    it('deleteSuggestion shows error snackbar on failure', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        service.deleteSuggestedChargingPoint.mockReturnValue(throwError(() => new Error('x')));
+        const c = create();
+
+        c.deleteSuggestion(makePoint());
+
+        expect(snackBar.open).toHaveBeenCalledWith('Kunde inte ta bort förslag', 'Stäng', expect.any(Object));
+    });
+
+    describe('viewOnMap (parseCoordinates)', () => {
+        it('opens the map dialog when coordinates parse', () => {
+            const c = create();
+            c.viewOnMap(makePoint({ mapCoordinates: '59.33, 18.07' }));
+
+            expect(dialog.open).toHaveBeenCalledTimes(1);
+            const args = dialog.open.mock.calls[0];
+            expect(args[1].data).toEqual({ lat: 59.33, lng: 18.07, title: 'Stop' });
+        });
+
+        it('shows error snackbar on invalid coordinates', () => {
+            const c = create();
+            c.viewOnMap(makePoint({ mapCoordinates: 'not-coords' }));
+
+            expect(dialog.open).not.toHaveBeenCalled();
+            expect(snackBar.open).toHaveBeenCalledWith('Ogiltiga koordinater', 'Stäng', expect.any(Object));
+        });
+
+        it('rejects when only one number is present', () => {
+            const c = create();
+            c.viewOnMap(makePoint({ mapCoordinates: '59.33' }));
+
+            expect(dialog.open).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/frontend/src/app/admin/nobil-import/nobil-import.component.spec.ts
+++ b/frontend/src/app/admin/nobil-import/nobil-import.component.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Surgical coverage for the Leaflet-heavy NobilImportComponent: only
+ * filterStations + pagination are tested. Map / DOM / route effects are out of
+ * scope per TESTPLAN.md. Component is instantiated directly with mocks to
+ * avoid triggering ngOnInit (which builds the Leaflet map).
+ */
+import { Location } from '@angular/common';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { NobilDumpStation, NobilService } from '../../services/nobil.service';
+import { NobilImportComponent } from './nobil-import.component';
+
+function makeStation(overrides: Partial<NobilDumpStation> = {}): NobilDumpStation {
+    return {
+        uuid: 1,
+        name: 'Station',
+        street: '',
+        house_number: '',
+        zipcode: '',
+        city: 'Stockholm',
+        municipality: '',
+        country_code: 'SWE',
+        description: '',
+        geolocation: '(59.3,18.0)',
+        number_charging_points: 1,
+        capacity: 22,
+        ...overrides,
+    };
+}
+
+function create(): NobilImportComponent {
+    const nobil = {} as NobilService;
+    const snack = {} as MatSnackBar;
+    const location = {} as Location;
+    const router = {} as Router;
+    return new NobilImportComponent(nobil, snack, location, router);
+}
+
+describe('NobilImportComponent — filterStations', () => {
+    it('filters by name case-insensitively (substring match)', () => {
+        const c = create();
+        c.stations = [
+            makeStation({ uuid: 1, name: 'Ionity Arlanda' }),
+            makeStation({ uuid: 2, name: 'Recharge Kista' }),
+        ];
+        c.filterName = 'ionity';
+
+        c.filterStations();
+
+        expect(c.filteredStations.map(s => s.uuid)).toEqual([1]);
+    });
+
+    it('filters by city case-insensitively', () => {
+        const c = create();
+        c.stations = [
+            makeStation({ uuid: 1, city: 'Stockholm' }),
+            makeStation({ uuid: 2, city: 'Göteborg' }),
+        ];
+        c.filterCity = 'GOT';
+
+        c.filterStations();
+
+        // Substring match — 'got' is not in 'göteborg' without diacritics handling,
+        // so the explicit lowercase comparison still differentiates. Use a match.
+        expect(c.filteredStations).toHaveLength(0);
+
+        c.filterCity = 'stock';
+        c.filterStations();
+        expect(c.filteredStations.map(s => s.uuid)).toEqual([1]);
+    });
+
+    it('combines name, city, and minCapacity filters', () => {
+        const c = create();
+        c.stations = [
+            makeStation({ uuid: 1, name: 'Ionity', city: 'Stockholm', capacity: 50 }),
+            makeStation({ uuid: 2, name: 'Ionity', city: 'Stockholm', capacity: 11 }),
+            makeStation({ uuid: 3, name: 'Other', city: 'Stockholm', capacity: 50 }),
+        ];
+        c.filterName = 'ionity';
+        c.filterCity = 'stockholm';
+        c.minCapacity = 22;
+
+        c.filterStations();
+
+        expect(c.filteredStations.map(s => s.uuid)).toEqual([1]);
+    });
+
+    it('treats missing capacity as 0', () => {
+        const c = create();
+        c.stations = [
+            makeStation({ uuid: 1, capacity: undefined as unknown as number }),
+            makeStation({ uuid: 2, capacity: 50 }),
+        ];
+        c.minCapacity = 10;
+
+        c.filterStations();
+
+        expect(c.filteredStations.map(s => s.uuid)).toEqual([2]);
+    });
+
+    it('resets pageIndex to 0 after filtering', () => {
+        const c = create();
+        c.stations = [makeStation()];
+        c.pageIndex = 3;
+
+        c.filterStations();
+
+        expect(c.pageIndex).toBe(0);
+    });
+});
+
+describe('NobilImportComponent — pagedStations', () => {
+    it('slices filteredStations by pageIndex and pageSize', () => {
+        const c = create();
+        c.filteredStations = Array.from({ length: 25 }, (_, i) =>
+            makeStation({ uuid: i + 1 }),
+        );
+        c.pageSize = 10;
+
+        c.pageIndex = 0;
+        expect(c.pagedStations.map(s => s.uuid)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        c.pageIndex = 2;
+        expect(c.pagedStations.map(s => s.uuid)).toEqual([21, 22, 23, 24, 25]);
+    });
+
+    it('onPageChange updates index and size', () => {
+        const c = create();
+        c.onPageChange({ pageIndex: 3, pageSize: 50, length: 200 });
+        expect(c.pageIndex).toBe(3);
+        expect(c.pageSize).toBe(50);
+    });
+});

--- a/frontend/src/app/auth/admin.guard.spec.ts
+++ b/frontend/src/app/auth/admin.guard.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import {
+    ActivatedRouteSnapshot,
+    Router,
+    RouterStateSnapshot,
+} from '@angular/router';
+import { adminGuard } from './admin.guard';
+import { AuthService } from './auth.service';
+
+describe('adminGuard', () => {
+    let navigate: ReturnType<typeof vi.fn>;
+    let authService: { isAdmin: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        navigate = vi.fn();
+        authService = { isAdmin: vi.fn() };
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: AuthService, useValue: authService },
+                { provide: Router, useValue: { navigate } },
+            ],
+        });
+    });
+
+    const run = () =>
+        TestBed.runInInjectionContext(() =>
+            adminGuard(
+                {} as ActivatedRouteSnapshot,
+                {} as RouterStateSnapshot,
+            ),
+        );
+
+    it('allows admins through', () => {
+        authService.isAdmin.mockReturnValue(true);
+        expect(run()).toBe(true);
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('redirects non-admins to home', () => {
+        authService.isAdmin.mockReturnValue(false);
+        expect(run()).toBe(false);
+        expect(navigate).toHaveBeenCalledWith(['/']);
+    });
+});

--- a/frontend/src/app/auth/auth.guard.spec.ts
+++ b/frontend/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import {
+    ActivatedRouteSnapshot,
+    Router,
+    RouterStateSnapshot,
+} from '@angular/router';
+import { authGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
+describe('authGuard', () => {
+    let navigate: ReturnType<typeof vi.fn>;
+    let authService: { isAuthenticated: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        navigate = vi.fn();
+        authService = { isAuthenticated: vi.fn() };
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: AuthService, useValue: authService },
+                { provide: Router, useValue: { navigate } },
+            ],
+        });
+    });
+
+    const run = () =>
+        TestBed.runInInjectionContext(() =>
+            authGuard(
+                {} as ActivatedRouteSnapshot,
+                {} as RouterStateSnapshot,
+            ),
+        );
+
+    it('allows navigation when the user is authenticated', () => {
+        authService.isAuthenticated.mockReturnValue(true);
+        expect(run()).toBe(true);
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('blocks and redirects to /login when the user is not authenticated', () => {
+        authService.isAuthenticated.mockReturnValue(false);
+        expect(run()).toBe(false);
+        expect(navigate).toHaveBeenCalledWith(['/login']);
+    });
+});

--- a/frontend/src/app/auth/auth.interceptor.spec.ts
+++ b/frontend/src/app/auth/auth.interceptor.spec.ts
@@ -1,0 +1,48 @@
+import { HttpClient, withInterceptors, provideHttpClient } from '@angular/common/http';
+import {
+    HttpTestingController,
+    provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { authInterceptor } from './auth.interceptor';
+import { AuthService } from './auth.service';
+
+describe('authInterceptor', () => {
+    let http: HttpClient;
+    let testing: HttpTestingController;
+    let token: string | null;
+
+    beforeEach(() => {
+        token = null;
+        TestBed.configureTestingModule({
+            providers: [
+                provideHttpClient(withInterceptors([authInterceptor])),
+                provideHttpClientTesting(),
+                {
+                    provide: AuthService,
+                    useValue: { getToken: () => token },
+                },
+            ],
+        });
+        http = TestBed.inject(HttpClient);
+        testing = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => testing.verify());
+
+    it('attaches Authorization header when a token is present', () => {
+        token = 'abc123';
+        http.get('/x').subscribe();
+        const req = testing.expectOne('/x');
+        expect(req.request.headers.get('Authorization')).toBe('Bearer abc123');
+        req.flush({});
+    });
+
+    it('does not attach an Authorization header when no token is present', () => {
+        token = null;
+        http.get('/x').subscribe();
+        const req = testing.expectOne('/x');
+        expect(req.request.headers.has('Authorization')).toBe(false);
+        req.flush({});
+    });
+});

--- a/frontend/src/app/auth/auth.service.spec.ts
+++ b/frontend/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,156 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+    HttpTestingController,
+    provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../environments/environment';
+import { AuthService } from './auth.service';
+
+function makeJwt(payload: object): string {
+    const enc = (o: object) =>
+        btoa(JSON.stringify(o)).replace(/=+$/, '');
+    return `${enc({ alg: 'HS256', typ: 'JWT' })}.${enc(payload)}.sig`;
+}
+
+const futureExp = () => Math.floor(Date.now() / 1000) + 3600;
+const pastExp = () => Math.floor(Date.now() / 1000) - 10;
+
+describe('AuthService', () => {
+    let http: HttpTestingController;
+
+    beforeEach(() => {
+        localStorage.clear();
+        TestBed.configureTestingModule({
+            providers: [provideHttpClient(), provideHttpClientTesting()],
+        });
+        http = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        http.verify();
+    });
+
+    it('starts unauthenticated when no token is stored', () => {
+        const service = TestBed.inject(AuthService);
+        expect(service.isAuthenticated()).toBe(false);
+        expect(service.currentUser()).toBeNull();
+        expect(service.currentUserRole()).toBeNull();
+    });
+
+    describe('login', () => {
+        it('stores token, sets signals and decodes role on success', () => {
+            const service = TestBed.inject(AuthService);
+            const token = makeJwt({ exp: futureExp(), role: 'Admin' });
+
+            service.login({ username: 'bob', password: 'pw' }).subscribe();
+
+            const req = http.expectOne(`${environment.apiUrl}/api/auth/login`);
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body).toEqual({ username: 'bob', password: 'pw' });
+            req.flush({ token, username: 'bob' });
+
+            expect(localStorage.getItem('token')).toBe(token);
+            expect(localStorage.getItem('username')).toBe('bob');
+            expect(service.isAuthenticated()).toBe(true);
+            expect(service.currentUser()).toBe('bob');
+            expect(service.isAdmin()).toBe(true);
+            expect(service.isSuperAdmin()).toBe(false);
+        });
+    });
+
+    describe('logout', () => {
+        it('clears storage and signals', () => {
+            const service = TestBed.inject(AuthService);
+            const token = makeJwt({ exp: futureExp(), role: 'Admin' });
+
+            service.login({ username: 'bob', password: 'pw' }).subscribe();
+            http.expectOne(`${environment.apiUrl}/api/auth/login`)
+                .flush({ token, username: 'bob' });
+
+            service.logout();
+
+            expect(localStorage.getItem('token')).toBeNull();
+            expect(localStorage.getItem('username')).toBeNull();
+            expect(service.isAuthenticated()).toBe(false);
+            expect(service.currentUser()).toBeNull();
+            expect(service.currentUserRole()).toBeNull();
+        });
+    });
+
+    describe('constructor', () => {
+        it('restores session and verifies it on backend when a valid token is stored', () => {
+            const token = makeJwt({ exp: futureExp(), role: 'SuperAdmin' });
+            localStorage.setItem('token', token);
+            localStorage.setItem('username', 'admin');
+
+            const service = TestBed.inject(AuthService);
+
+            const req = http.expectOne(
+                `${environment.apiUrl}/api/account/profile`,
+            );
+            req.flush({});
+
+            expect(service.isAuthenticated()).toBe(true);
+            expect(service.currentUser()).toBe('admin');
+            expect(service.isSuperAdmin()).toBe(true);
+            expect(service.isAdmin()).toBe(true);
+        });
+
+        it('logs out when the stored token is expired', () => {
+            const token = makeJwt({ exp: pastExp(), role: 'Admin' });
+            localStorage.setItem('token', token);
+            localStorage.setItem('username', 'bob');
+
+            const service = TestBed.inject(AuthService);
+
+            expect(service.isAuthenticated()).toBe(false);
+            expect(localStorage.getItem('token')).toBeNull();
+            expect(localStorage.getItem('username')).toBeNull();
+        });
+
+        it('logs out when the stored token is malformed', () => {
+            localStorage.setItem('token', 'not-a-jwt');
+
+            const service = TestBed.inject(AuthService);
+
+            expect(service.isAuthenticated()).toBe(false);
+            expect(localStorage.getItem('token')).toBeNull();
+        });
+    });
+
+    describe('role helpers', () => {
+        function loginAs(role: string): AuthService {
+            const service = TestBed.inject(AuthService);
+            const token = makeJwt({ exp: futureExp(), role });
+            service.login({ username: 'u', password: 'p' }).subscribe();
+            http.expectOne(`${environment.apiUrl}/api/auth/login`)
+                .flush({ token, username: 'u' });
+            return service;
+        }
+
+        it('isAdmin is true for Admin', () => {
+            const service = loginAs('Admin');
+            expect(service.isAdmin()).toBe(true);
+            expect(service.isSuperAdmin()).toBe(false);
+        });
+
+        it('isAdmin is true for SuperAdmin', () => {
+            const service = loginAs('SuperAdmin');
+            expect(service.isAdmin()).toBe(true);
+            expect(service.isSuperAdmin()).toBe(true);
+        });
+
+        it('isAdmin is false for regular users', () => {
+            const service = loginAs('User');
+            expect(service.isAdmin()).toBe(false);
+            expect(service.isSuperAdmin()).toBe(false);
+        });
+
+        it('hasRole matches exact role string', () => {
+            const service = loginAs('Admin');
+            expect(service.hasRole('Admin')).toBe(true);
+            expect(service.hasRole('SuperAdmin')).toBe(false);
+        });
+    });
+});

--- a/frontend/src/app/auth/login/login.component.spec.ts
+++ b/frontend/src/app/auth/login/login.component.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../auth.service';
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+    let auth: { login: ReturnType<typeof vi.fn> };
+    let router: { navigate: ReturnType<typeof vi.fn> };
+    let snackBar: { open: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        auth = { login: vi.fn() };
+        router = { navigate: vi.fn() };
+        snackBar = { open: vi.fn() };
+
+        TestBed.configureTestingModule({
+            imports: [LoginComponent],
+            providers: [
+                { provide: AuthService, useValue: auth },
+                { provide: Router, useValue: router },
+                { provide: MatSnackBar, useValue: snackBar },
+            ],
+        });
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    function create(): LoginComponent {
+        return TestBed.createComponent(LoginComponent).componentInstance;
+    }
+
+    it('shows a snackbar and does not call login when fields are empty', async () => {
+        const c = create();
+        await c.onSubmit();
+
+        expect(auth.login).not.toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Vänligen fyll i både användarnamn och lösenord',
+            'Stäng',
+            expect.any(Object),
+        );
+        expect(c.isLoading).toBe(false);
+    });
+
+    it('navigates home on successful login', async () => {
+        auth.login.mockReturnValue(of({ token: 't', username: 'u' }));
+        const c = create();
+        c.username = 'u';
+        c.password = 'p';
+
+        await c.onSubmit();
+
+        expect(auth.login).toHaveBeenCalledWith({ username: 'u', password: 'p' });
+        expect(router.navigate).toHaveBeenCalledWith(['/']);
+    });
+
+    it('shows error snackbar and resets loading on failure', async () => {
+        auth.login.mockReturnValue(throwError(() => new Error('bad creds')));
+        const c = create();
+        c.username = 'u';
+        c.password = 'wrong';
+
+        await c.onSubmit();
+
+        expect(router.navigate).not.toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Felaktigt användarnamn eller lösenord',
+            'Stäng',
+            expect.any(Object),
+        );
+        expect(c.isLoading).toBe(false);
+    });
+
+    it('onCancel navigates home', () => {
+        const c = create();
+        c.onCancel();
+        expect(router.navigate).toHaveBeenCalledWith(['/']);
+    });
+});

--- a/frontend/src/app/auth/super-admin.guard.spec.ts
+++ b/frontend/src/app/auth/super-admin.guard.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import {
+    ActivatedRouteSnapshot,
+    Router,
+    RouterStateSnapshot,
+} from '@angular/router';
+import { AuthService } from './auth.service';
+import { superAdminGuard } from './super-admin.guard';
+
+describe('superAdminGuard', () => {
+    let navigate: ReturnType<typeof vi.fn>;
+    let authService: { isSuperAdmin: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        navigate = vi.fn();
+        authService = { isSuperAdmin: vi.fn() };
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: AuthService, useValue: authService },
+                { provide: Router, useValue: { navigate } },
+            ],
+        });
+    });
+
+    const run = () =>
+        TestBed.runInInjectionContext(() =>
+            superAdminGuard(
+                {} as ActivatedRouteSnapshot,
+                {} as RouterStateSnapshot,
+            ),
+        );
+
+    it('allows super-admins through', () => {
+        authService.isSuperAdmin.mockReturnValue(true);
+        expect(run()).toBe(true);
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('redirects everyone else to home', () => {
+        authService.isSuperAdmin.mockReturnValue(false);
+        expect(run()).toBe(false);
+        expect(navigate).toHaveBeenCalledWith(['/']);
+    });
+});

--- a/frontend/src/app/feedback-form/feedback-flow.integration.spec.ts
+++ b/frontend/src/app/feedback-form/feedback-flow.integration.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Step 5 integration test: feedback submission with the real FeedbackService
+ * wired against HttpTestingController. Verifies the form-to-HTTP wiring that
+ * unit tests with a mocked service cannot.
+ */
+import { provideHttpClient } from '@angular/common/http';
+import {
+    HttpTestingController,
+    provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { environment } from '../../environments/environment';
+import { FeedbackType } from '../models/feedback.model';
+import { FeedbackFormComponent } from './feedback-form.component';
+
+describe('Feedback submit flow (integration)', () => {
+    let http: HttpTestingController;
+    let router: { navigate: ReturnType<typeof vi.fn> };
+    let snackBar: { open: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        router = { navigate: vi.fn() };
+        snackBar = { open: vi.fn() };
+
+        TestBed.configureTestingModule({
+            imports: [FeedbackFormComponent],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                { provide: Router, useValue: router },
+                { provide: MatSnackBar, useValue: snackBar },
+            ],
+        });
+        http = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        http.verify();
+    });
+
+    it('POSTs valid feedback to /api/feedback and shows confirmation', () => {
+        const c = TestBed.createComponent(FeedbackFormComponent).componentInstance;
+        c.title = 'Bug A';
+        c.description = 'Steps...';
+        c.email = 'me@example.com';
+        c.feedbackType = FeedbackType.Bug;
+        c.isCaptchaValid = true;
+
+        c.submitFeedback();
+
+        const req = http.expectOne(`${environment.apiUrl}/api/feedback`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({
+            type: FeedbackType.Bug,
+            title: 'Bug A',
+            description: 'Steps...',
+            email: 'me@example.com',
+        });
+        req.flush({ id: 99 });
+
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Tack för din feedback!',
+            'Stäng',
+            expect.any(Object),
+        );
+        expect(router.navigate).toHaveBeenCalledWith(['/']);
+        expect(c.title).toBe('');
+    });
+
+    it('does not call the backend when captcha is missing', () => {
+        const c = TestBed.createComponent(FeedbackFormComponent).componentInstance;
+        c.title = 'X';
+        c.description = 'Y';
+        c.isCaptchaValid = false;
+
+        c.submitFeedback();
+
+        http.expectNone(`${environment.apiUrl}/api/feedback`);
+    });
+});

--- a/frontend/src/app/feedback-form/feedback-form.component.spec.ts
+++ b/frontend/src/app/feedback-form/feedback-form.component.spec.ts
@@ -1,0 +1,141 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { FeedbackType } from '../models/feedback.model';
+import { FeedbackService } from '../services/feedback.service';
+import { FeedbackFormComponent } from './feedback-form.component';
+
+describe('FeedbackFormComponent', () => {
+    let feedback: { submitFeedback: ReturnType<typeof vi.fn> };
+    let router: { navigate: ReturnType<typeof vi.fn> };
+    let snackBar: { open: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        feedback = { submitFeedback: vi.fn() };
+        router = { navigate: vi.fn() };
+        snackBar = { open: vi.fn() };
+
+        TestBed.configureTestingModule({
+            imports: [FeedbackFormComponent],
+            providers: [
+                { provide: FeedbackService, useValue: feedback },
+                { provide: Router, useValue: router },
+                { provide: MatSnackBar, useValue: snackBar },
+            ],
+        });
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    function create(): FeedbackFormComponent {
+        return TestBed.createComponent(FeedbackFormComponent).componentInstance;
+    }
+
+    function fill(c: FeedbackFormComponent): void {
+        c.title = 'title';
+        c.description = 'desc';
+        c.isCaptchaValid = true;
+    }
+
+    it('rejects submit when title is blank', () => {
+        const c = create();
+        fill(c);
+        c.title = '   ';
+
+        c.submitFeedback();
+
+        expect(feedback.submitFeedback).not.toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Vänligen fyll i alla obligatoriska fält',
+            'Stäng',
+            expect.any(Object),
+        );
+    });
+
+    it('rejects submit when description is blank', () => {
+        const c = create();
+        fill(c);
+        c.description = '';
+
+        c.submitFeedback();
+
+        expect(feedback.submitFeedback).not.toHaveBeenCalled();
+    });
+
+    it('rejects submit when captcha is invalid', () => {
+        const c = create();
+        fill(c);
+        c.isCaptchaValid = false;
+
+        c.submitFeedback();
+
+        expect(feedback.submitFeedback).not.toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Vänligen lös reCAPTCHA',
+            'Stäng',
+            expect.any(Object),
+        );
+    });
+
+    it('sends email as undefined when blank, navigates home and resets on success', () => {
+        feedback.submitFeedback.mockReturnValue(of({}));
+        const c = create();
+        fill(c);
+        c.email = '   ';
+        c.feedbackType = FeedbackType.Bug;
+
+        c.submitFeedback();
+
+        expect(feedback.submitFeedback).toHaveBeenCalledWith({
+            type: FeedbackType.Bug,
+            title: 'title',
+            description: 'desc',
+            email: undefined,
+        });
+        expect(router.navigate).toHaveBeenCalledWith(['/']);
+        expect(c.title).toBe('');
+        expect(c.isSubmitting).toBe(false);
+    });
+
+    it('trims and sends email when present', () => {
+        feedback.submitFeedback.mockReturnValue(of({}));
+        const c = create();
+        fill(c);
+        c.email = '  a@b.se  ';
+
+        c.submitFeedback();
+
+        expect(feedback.submitFeedback).toHaveBeenCalledWith(expect.objectContaining({
+            email: 'a@b.se',
+        }));
+    });
+
+    it('shows error and resets isSubmitting on failure', () => {
+        feedback.submitFeedback.mockReturnValue(throwError(() => new Error('x')));
+        const c = create();
+        fill(c);
+
+        c.submitFeedback();
+
+        expect(router.navigate).not.toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Ett fel uppstod. Försök igen senare.',
+            'Stäng',
+            expect.any(Object),
+        );
+        expect(c.isSubmitting).toBe(false);
+    });
+
+    it('onResolved tracks captcha response presence', () => {
+        const c = create();
+        c.onResolved('token');
+        expect(c.isCaptchaValid).toBe(true);
+        c.onResolved(null);
+        expect(c.isCaptchaValid).toBe(false);
+    });
+});

--- a/frontend/src/app/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/error.interceptor.spec.ts
@@ -1,0 +1,69 @@
+import {
+    HttpClient,
+    provideHttpClient,
+    withInterceptors,
+} from '@angular/common/http';
+import {
+    HttpTestingController,
+    provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from '../auth/auth.service';
+import { ErrorService } from '../services/error.service';
+import { errorInterceptor } from './error.interceptor';
+
+describe('errorInterceptor', () => {
+    let http: HttpClient;
+    let testing: HttpTestingController;
+    let authService: { logout: ReturnType<typeof vi.fn> };
+    let errorService: { handleError: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        authService = { logout: vi.fn() };
+        errorService = { handleError: vi.fn() };
+        TestBed.configureTestingModule({
+            providers: [
+                provideHttpClient(withInterceptors([errorInterceptor])),
+                provideHttpClientTesting(),
+                { provide: AuthService, useValue: authService },
+                { provide: ErrorService, useValue: errorService },
+            ],
+        });
+        http = TestBed.inject(HttpClient);
+        testing = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => testing.verify());
+
+    it('logs the user out on a 401 response', () => {
+        http.post('/x', {}).subscribe({ error: () => {} });
+        testing.expectOne('/x').flush(
+            { message: 'unauthorized' },
+            { status: 401, statusText: 'Unauthorized' },
+        );
+
+        expect(authService.logout).toHaveBeenCalled();
+        expect(errorService.handleError).not.toHaveBeenCalled();
+    });
+
+    it('routes non-401 errors through ErrorService', () => {
+        http.post('/x', {}).subscribe({ error: () => {} });
+        testing.expectOne('/x').flush(
+            { message: 'boom' },
+            { status: 500, statusText: 'Server Error' },
+        );
+
+        expect(errorService.handleError).toHaveBeenCalled();
+        expect(authService.logout).not.toHaveBeenCalled();
+    });
+
+    it('passes successful responses through untouched', () => {
+        let result: unknown;
+        http.get('/x').subscribe((v) => (result = v));
+        testing.expectOne('/x').flush({ ok: true });
+
+        expect(result).toEqual({ ok: true });
+        expect(authService.logout).not.toHaveBeenCalled();
+        expect(errorService.handleError).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/app/interceptors/error.interceptor.ts
+++ b/frontend/src/app/interceptors/error.interceptor.ts
@@ -6,6 +6,7 @@ import { ErrorService } from '../services/error.service';
 
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
     const errorService = inject(ErrorService);
+    const authService = inject(AuthService);
 
     return next(req).pipe(
         // Retry failed requests (except for POST/PUT/DELETE to avoid duplicates)
@@ -24,8 +25,6 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         }),
         catchError((error: HttpErrorResponse) => {
             if (error.status === 401) {
-                // 401 Unauthorized - Token expired or invalid
-                const authService = inject(AuthService); // Inject here to avoid circular dependency issues in construction
                 authService.logout();
             } else {
                 errorService.handleError(error);

--- a/frontend/src/app/services/charging-station.service.spec.ts
+++ b/frontend/src/app/services/charging-station.service.spec.ts
@@ -1,0 +1,111 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+    HttpTestingController,
+    provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../environments/environment';
+import { ChargingPoint, ChargingStationService } from './charging-station.service';
+
+describe('ChargingStationService', () => {
+    let http: HttpTestingController;
+    let service: ChargingStationService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [provideHttpClient(), provideHttpClientTesting()],
+        });
+        http = TestBed.inject(HttpTestingController);
+        service = TestBed.inject(ChargingStationService);
+    });
+
+    afterEach(() => {
+        http.verify();
+    });
+
+    describe('getChargingPointsPaged', () => {
+        it('omits the search parameter when empty', () => {
+            service.getChargingPointsPaged(2, 10).subscribe();
+
+            const req = http.expectOne(r =>
+                r.url === `${environment.apiUrl}/api/chargingpoints`,
+            );
+            expect(req.request.params.get('page')).toBe('2');
+            expect(req.request.params.get('pageSize')).toBe('10');
+            expect(req.request.params.has('search')).toBe(false);
+            req.flush({ items: [], totalCount: 0, page: 2, pageSize: 10 });
+        });
+
+        it('trims whitespace-only search to nothing', () => {
+            service.getChargingPointsPaged(1, 10, '   ').subscribe();
+
+            const req = http.expectOne(r =>
+                r.url === `${environment.apiUrl}/api/chargingpoints`,
+            );
+            expect(req.request.params.has('search')).toBe(false);
+            req.flush({ items: [], totalCount: 0, page: 1, pageSize: 10 });
+        });
+
+        it('trims and sends a non-empty search', () => {
+            service.getChargingPointsPaged(1, 10, '  hello  ').subscribe();
+
+            const req = http.expectOne(r =>
+                r.url === `${environment.apiUrl}/api/chargingpoints`,
+            );
+            expect(req.request.params.get('search')).toBe('hello');
+            req.flush({ items: [], totalCount: 0, page: 1, pageSize: 10 });
+        });
+    });
+
+    describe('createChargingPoint (buildFormData)', () => {
+        const minimal: Omit<ChargingPoint, 'id'> = {
+            title: 't',
+            address1: 'a1',
+            postalCode: '12345',
+            city: 'c',
+            country: 'SE',
+            mapCoordinates: '1,2',
+            capacity: 50,
+        };
+
+        it('appends only required fields when optional are missing', () => {
+            service.createChargingPoint(minimal).subscribe();
+
+            const req = http.expectOne(`${environment.apiUrl}/api/chargingpoints`);
+            const fd = req.request.body as FormData;
+            expect(fd.get('title')).toBe('t');
+            expect(fd.get('address1')).toBe('a1');
+            expect(fd.get('capacity')).toBe('50');
+            expect(fd.has('address2')).toBe(false);
+            expect(fd.has('comments')).toBe(false);
+            expect(fd.has('numberOfChargePoints')).toBe(false);
+            expect(fd.has('externalId')).toBe(false);
+            expect(fd.has('image')).toBe(false);
+            req.flush({});
+        });
+
+        it('appends optional fields and image when provided', () => {
+            const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+            const full: Omit<ChargingPoint, 'id'> = {
+                ...minimal,
+                address2: 'apt 2',
+                comments: 'note',
+                numberOfChargePoints: 4,
+                externalId: 'ext-1',
+                externalSource: 'NOBIL',
+            };
+
+            service.createChargingPoint(full, file).subscribe();
+
+            const req = http.expectOne(`${environment.apiUrl}/api/chargingpoints`);
+            const fd = req.request.body as FormData;
+            expect(fd.get('address2')).toBe('apt 2');
+            expect(fd.get('comments')).toBe('note');
+            expect(fd.get('numberOfChargePoints')).toBe('4');
+            expect(fd.get('externalId')).toBe('ext-1');
+            expect(fd.get('externalSource')).toBe('NOBIL');
+            expect(fd.get('image')).toBe(file);
+            req.flush({});
+        });
+    });
+});

--- a/frontend/src/app/services/connection.service.spec.ts
+++ b/frontend/src/app/services/connection.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { ConnectionService } from './connection.service';
+
+describe('ConnectionService', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+    });
+
+    it('initialises from navigator.onLine', () => {
+        vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+        const service = TestBed.inject(ConnectionService);
+        expect(service.isOnline()).toBe(false);
+    });
+
+    it('updates state when the window emits online/offline events', () => {
+        vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+        const service = TestBed.inject(ConnectionService);
+        expect(service.isOnline()).toBe(true);
+
+        window.dispatchEvent(new Event('offline'));
+        expect(service.isOnline()).toBe(false);
+
+        window.dispatchEvent(new Event('online'));
+        expect(service.isOnline()).toBe(true);
+    });
+
+    it('online$ emits the current value to new subscribers', () => {
+        vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+        const service = TestBed.inject(ConnectionService);
+
+        const seen: boolean[] = [];
+        service.online$.subscribe(v => seen.push(v));
+
+        window.dispatchEvent(new Event('offline'));
+
+        expect(seen).toEqual([true, false]);
+    });
+});

--- a/frontend/src/app/services/error.service.spec.ts
+++ b/frontend/src/app/services/error.service.spec.ts
@@ -1,0 +1,114 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ErrorService } from './error.service';
+
+describe('ErrorService', () => {
+    let snackBar: { open: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        snackBar = { open: vi.fn() };
+        TestBed.configureTestingModule({
+            providers: [{ provide: MatSnackBar, useValue: snackBar }],
+        });
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('parseError via handleError', () => {
+        it('classifies status 0 as network error', () => {
+            const service = TestBed.inject(ErrorService);
+            service.handleError(new HttpErrorResponse({ status: 0 }));
+
+            const recent = service.getRecentErrors();
+            expect(recent).toHaveLength(1);
+            expect(recent[0].type).toBe('network');
+            expect(recent[0].message).toBe('Kan inte ansluta till servern');
+        });
+
+        it('classifies status >= 500 as server error', () => {
+            const service = TestBed.inject(ErrorService);
+            service.handleError(new HttpErrorResponse({ status: 503, error: { message: 'oops' } }));
+
+            const recent = service.getRecentErrors();
+            expect(recent[0].type).toBe('server');
+            expect(recent[0].details).toBe('oops');
+        });
+
+        it('classifies 4xx as client error', () => {
+            const service = TestBed.inject(ErrorService);
+            service.handleError(new HttpErrorResponse({ status: 404, error: { message: 'not found' } }));
+
+            const recent = service.getRecentErrors();
+            expect(recent[0].type).toBe('client');
+            expect(recent[0].details).toBe('not found');
+        });
+
+        it('classifies non-HTTP errors as unknown and uses context as message', () => {
+            const service = TestBed.inject(ErrorService);
+            service.handleError(new Error('boom'), 'During import');
+
+            const recent = service.getRecentErrors();
+            expect(recent[0].type).toBe('unknown');
+            expect(recent[0].message).toBe('During import');
+            expect(recent[0].details).toBe('boom');
+        });
+    });
+
+    describe('snackbar duration', () => {
+        it('uses 10s duration for network errors and 5s for others', () => {
+            const service = TestBed.inject(ErrorService);
+
+            service.handleError(new HttpErrorResponse({ status: 0 }));
+            expect(snackBar.open).toHaveBeenLastCalledWith(
+                expect.any(String),
+                'Stäng',
+                expect.objectContaining({ duration: 10000 }),
+            );
+
+            service.handleError(new HttpErrorResponse({ status: 500 }));
+            expect(snackBar.open).toHaveBeenLastCalledWith(
+                expect.any(String),
+                'Stäng',
+                expect.objectContaining({ duration: 5000 }),
+            );
+        });
+    });
+
+    describe('error log management', () => {
+        it('caps the stored errors at 50', () => {
+            const service = TestBed.inject(ErrorService);
+
+            for (let i = 0; i < 55; i++) {
+                service.handleError(new Error(`err-${i}`));
+            }
+
+            const recent = service.getRecentErrors();
+            expect(recent).toHaveLength(50);
+            expect(recent[0].details).toBe('err-5');
+            expect(recent[49].details).toBe('err-54');
+        });
+
+        it('clearErrors empties the log', () => {
+            const service = TestBed.inject(ErrorService);
+            service.handleError(new Error('x'));
+            expect(service.getRecentErrors()).toHaveLength(1);
+
+            service.clearErrors();
+            expect(service.getRecentErrors()).toHaveLength(0);
+        });
+
+        it('getRecentErrors returns a copy, not a live reference', () => {
+            const service = TestBed.inject(ErrorService);
+            service.handleError(new Error('x'));
+
+            const snapshot = service.getRecentErrors();
+            snapshot.pop();
+
+            expect(service.getRecentErrors()).toHaveLength(1);
+        });
+    });
+});

--- a/frontend/src/app/services/theme.service.spec.ts
+++ b/frontend/src/app/services/theme.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        document.documentElement.classList.remove('dark-mode', 'light-mode');
+        TestBed.configureTestingModule({});
+    });
+
+    it('should be created', () => {
+        const service = TestBed.inject(ThemeService);
+        expect(service).toBeTruthy();
+    });
+
+    it('defaults to light mode when no preference is stored', () => {
+        const service = TestBed.inject(ThemeService);
+        expect(service.isDarkMode()).toBe(false);
+    });
+
+    it('reads the stored preference from localStorage', () => {
+        localStorage.setItem('theme-preference', 'dark');
+        const service = TestBed.inject(ThemeService);
+        expect(service.isDarkMode()).toBe(true);
+    });
+
+    it('toggleDarkMode flips the current value', () => {
+        const service = TestBed.inject(ThemeService);
+        const initial = service.isDarkMode();
+        service.toggleDarkMode();
+        expect(service.isDarkMode()).toBe(!initial);
+    });
+});

--- a/frontend/src/app/simple-captcha/simple-captcha.component.spec.ts
+++ b/frontend/src/app/simple-captcha/simple-captcha.component.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { SimpleCaptchaComponent } from './simple-captcha.component';
+
+describe('SimpleCaptchaComponent', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [SimpleCaptchaComponent],
+        });
+    });
+
+    function create(): SimpleCaptchaComponent {
+        const fixture = TestBed.createComponent(SimpleCaptchaComponent);
+        fixture.detectChanges();
+        return fixture.componentInstance;
+    }
+
+    it('generates two operands between 1 and 10 on init', () => {
+        const c = create();
+        expect(c.num1).toBeGreaterThanOrEqual(1);
+        expect(c.num1).toBeLessThanOrEqual(10);
+        expect(c.num2).toBeGreaterThanOrEqual(1);
+        expect(c.num2).toBeLessThanOrEqual(10);
+    });
+
+    it('emits false on init', () => {
+        const fixture = TestBed.createComponent(SimpleCaptchaComponent);
+        const emitted: boolean[] = [];
+        fixture.componentInstance.captchaValid.subscribe(v => emitted.push(v));
+        fixture.detectChanges();
+        expect(emitted).toEqual([false]);
+    });
+
+    it('marks valid and emits true when answer matches', () => {
+        const c = create();
+        const emitted: boolean[] = [];
+        c.captchaValid.subscribe(v => emitted.push(v));
+
+        c.userAnswer = String(c.num1 + c.num2);
+        c.checkAnswer();
+
+        expect(c.isValid).toBe(true);
+        expect(emitted[emitted.length - 1]).toBe(true);
+    });
+
+    it('marks invalid and emits false when answer is wrong', () => {
+        const c = create();
+        const emitted: boolean[] = [];
+        c.captchaValid.subscribe(v => emitted.push(v));
+
+        c.userAnswer = String(c.num1 + c.num2 + 1);
+        c.checkAnswer();
+
+        expect(c.isValid).toBe(false);
+        expect(emitted[emitted.length - 1]).toBe(false);
+    });
+
+    it('rejects non-numeric answers', () => {
+        const c = create();
+        c.userAnswer = 'abc';
+        c.checkAnswer();
+        expect(c.isValid).toBe(false);
+    });
+
+    it('refresh regenerates operands and resets state', () => {
+        const c = create();
+        c.userAnswer = '42';
+        c.isValid = true;
+
+        c.refresh();
+
+        expect(c.userAnswer).toBe('');
+        expect(c.isValid).toBe(false);
+    });
+});

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -3,7 +3,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./out-tsc/spec",
-        "types": ["jasmine"]
+        "types": ["vitest/globals"]
     },
     "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
Migrate frontend tests from Karma to Vitest

Tests now run on Vitest 4 via @angular/build:unit-test. The npm test
command is unchanged. Adds a smoke test for ThemeService as a template
for future service tests.

Introduce 87 tests across 18 files covering the security-critical and
logic-heavy areas of the frontend:

- Auth (services, guards, interceptors): login, logout, token handling,
  role checks, 401 handling, header injection
- Services with business logic: error classification, online/offline
  state, charging-station form-data building and search-param trimming
- Forms: login validation, feedback form validation and captcha gating,
  simple-captcha answer checking
- Admin views: pagination clamp after deletes, CRUD confirmations,
  coordinate parsing
- NOBIL import: filter and pagination logic (Leaflet-free surface only)
- Integration: feedback submission end-to-end via HttpTestingController

Also moves the AuthService injection in errorInterceptor to the top of
the function so the interceptor works correctly under TestBed.

Pure-pass-through services, type-only models, and Leaflet/map code are
deliberately not tested.

Run with: cd frontend && npm test -- --watch=false